### PR TITLE
Move `__precompile__()` before `module`

### DIFF
--- a/src/Convertible.jl
+++ b/src/Convertible.jl
@@ -1,6 +1,6 @@
-module Convertible
-
 __precompile__()
+
+module Convertible
 
 import Base: convert, function_module
 import DataStructures: PriorityQueue, enqueue!, unshift!, dequeue!


### PR DESCRIPTION
According to the [manual](https://docs.julialang.org/en/stable/manual/modules.html#Module-initialization-and-precompilation-1), `__precompile__()` should go before `module`, even though it appears to be working anyway.